### PR TITLE
Update paths for /taxi/ deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Deploy
+
+1. Build the project:
+   `npm run build`
+2. Copy the contents of the generated `dist` directory to the `/taxi/` directory on your server.

--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TaxiLog</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="manifest" href="/manifest.json">
+  <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#0f172a">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="TaxiLog">
-  <link rel="apple-touch-icon" href="/icons/icon-192x192.png"> 
+  <link rel="apple-touch-icon" href="icons/icon-192x192.png">
 
 <script type="importmap">
 {
@@ -23,15 +23,15 @@
   }
 }
 </script>
-<link rel="stylesheet" href="/index.css">
+<link rel="stylesheet" href="index.css">
 </head>
 <body class="bg-slate-900 text-slate-100">
   <div id="root"></div>
-  <script type="module" src="/index.tsx"></script>
+  <script type="module" src="index.tsx"></script>
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/service-worker.js')
+        navigator.serviceWorker.register('service-worker.js')
           .then(registration => {
             console.log('ServiceWorker registration successful with scope: ', registration.scope);
           })

--- a/manifest.json
+++ b/manifest.json
@@ -2,56 +2,56 @@
   "name": "TaxiLog",
   "short_name": "TaxiLog",
   "description": "Vaš Osobni Dnevnik Taksi Poslovanja. Aplikacija za taksiste za praćenje dnevnih prihoda, kilometara, potrošnje goriva, zarade, troškova, radnih sati i broja vožnji. Pruža analizu podataka po danu, tjednu i mjesecu.",
-  "start_url": "/",
+  "start_url": "/taxi/",
   "display": "standalone",
   "background_color": "#0f172a",
   "theme_color": "#0284c7",
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "/icons/icon-72x72.png",
+      "src": "/taxi/icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-96x96.png",
+      "src": "/taxi/icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-128x128.png",
+      "src": "/taxi/icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-144x144.png",
+      "src": "/taxi/icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-152x152.png",
+      "src": "/taxi/icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-192x192.png",
+      "src": "/taxi/icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-384x384.png",
+      "src": "/taxi/icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-512x512.png",
+      "src": "/taxi/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,8 +1,8 @@
 const CACHE_NAME = 'taxilog-cache-v1.2'; // Promijenite verziju ako ažurirate datoteke
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/index.tsx', // Preglednik će zapravo keširati JS koji generira esm.sh za index.tsx
+  '/taxi/',
+  '/taxi/index.html',
+  '/taxi/index.tsx', // Preglednik će zapravo keširati JS koji generira esm.sh za index.tsx
   // CDN resursi - važno je da se i oni keširaju
   'https://cdn.tailwindcss.com',
   'https://esm.sh/react@^19.1.0',
@@ -13,7 +13,7 @@ const urlsToCache = [
   // npr. '/icons/icon-192x192.png', itd.
   // Za sada, nećemo eksplicitno dodavati sve ikone da lista ne bude preduga,
   // ali za potpunu offline funkcionalnost ikona, trebalo bi ih dodati.
-  '/manifest.json'
+  '/taxi/manifest.json'
 ];
 
 // Pre-cache React/ReactDOM/Recharts dependencies that esm.sh might resolve to
@@ -110,7 +110,7 @@ self.addEventListener('fetch', event => {
     event.respondWith(
       fetch(event.request)
         .catch(() => caches.match(event.request)) // Ako mreža ne uspije, vrati iz keša
-        .then(response => response || caches.match('/index.html')) // Ako ni to ne uspije, vrati index.html
+        .then(response => response || caches.match('/taxi/index.html')) // Ako ni to ne uspije, vrati index.html
     );
     return;
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: '/taxi/',
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)


### PR DESCRIPTION
## Summary
- configure Vite to use `/taxi/` as base path
- use relative assets in `index.html`
- adjust cache and fetch paths in `service-worker.js`
- update icons and start URL in `manifest.json`
- document how to build and deploy

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd8781c6c83278ddb668378a4f125