### PR TITLE
Fix manifest/icon paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TaxiLog</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="manifest" href="manifest.json">
+  <link rel="manifest" href="/taxi/manifest.json">
   <meta name="theme-color" content="#0f172a">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="TaxiLog">
-  <link rel="apple-touch-icon" href="icons/icon-192x192.png">
+  <link rel="apple-touch-icon" href="/taxi/icons/icon-192x192.png">
 
 <script type="importmap">
 {


### PR DESCRIPTION
## Summary
- use absolute paths for manifest and PWA icon

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddf1c7708832783ffca776bb33714